### PR TITLE
feat: fix including unprotected header from JAdES

### DIFF
--- a/packages/jades/src/sign.ts
+++ b/packages/jades/src/sign.ts
@@ -150,7 +150,16 @@ export class Sign<T extends Record<string, unknown>> {
     );
 
     const serialized = generalJSON.toJson();
-    this.serialized = serialized;
+    this.serialized = {
+      payload: serialized.payload,
+      signatures: serialized.signatures.map((sig) => ({
+        ...sig,
+        header: {
+          ...sig.header,
+          ...this.header,
+        },
+      })),
+    };
 
     return this;
   }


### PR DESCRIPTION
It closes #35 

I include unprotected header value from JAdES manually after the signning